### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/890/483/113/890483113.geojson
+++ b/data/890/483/113/890483113.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:eng_x_preferred":[
+        "Noven\u2019kiy"
+    ],
+    "name:rus_x_preferred":[
+        "\u041d\u043e\u0432\u0435\u043d\u044c\u043a\u0438\u0439"
+    ],
     "qs:name":"\u041d\u043e\u0432\u0435\u043d\u044c\u043a\u0438\u0439",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":890483113,
-    "wof:lastmodified":1566630672,
-    "wof:name":"\u041d\u043e\u0432\u0435\u043d\u044c\u043a\u0438\u0439",
+    "wof:lastmodified":1601068497,
+    "wof:name":"Noven\u2019kiy",
     "wof:parent_id":1108735633,
     "wof:placetype":"locality",
     "wof:population":23,

--- a/data/890/483/113/890483113.geojson
+++ b/data/890/483/113/890483113.geojson
@@ -31,11 +31,11 @@
     "qs:pop_sr":"1",
     "src:population":"geonames",
     "wof:belongsto":[
-        85688081,
         102191581,
         85632685,
+        1108735633,
         874393555,
-        1108735633
+        85688081
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":890483113,
-    "wof:lastmodified":1601068497,
+    "wof:lastmodified":1601423136,
     "wof:name":"Noven\u2019kiy",
     "wof:parent_id":1108735633,
     "wof:placetype":"locality",

--- a/data/890/487/203/890487203.geojson
+++ b/data/890/487/203/890487203.geojson
@@ -31,11 +31,11 @@
     "qs:pop_sr":"2",
     "src:population":"geonames",
     "wof:belongsto":[
-        85688023,
         102191581,
         85632685,
+        1108734387,
         874393555,
-        1108734387
+        85688023
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":890487203,
-    "wof:lastmodified":1601068497,
+    "wof:lastmodified":1601423136,
     "wof:name":"Dal\u2019zavodskoye",
     "wof:parent_id":1108734387,
     "wof:placetype":"locality",

--- a/data/890/487/203/890487203.geojson
+++ b/data/890/487/203/890487203.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:eng_x_preferred":[
+        "Dal\u2019zavodskoye"
+    ],
+    "name:rus_x_preferred":[
+        "\u0414\u0430\u043b\u044c\u0437\u0430\u0432\u043e\u0434\u0441\u043a\u043e\u0435"
+    ],
     "qs:name":"\u0414\u0430\u043b\u044c\u0437\u0430\u0432\u043e\u0434\u0441\u043a\u043e\u0435",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":890487203,
-    "wof:lastmodified":1566630907,
-    "wof:name":"\u0414\u0430\u043b\u044c\u0437\u0430\u0432\u043e\u0434\u0441\u043a\u043e\u0435",
+    "wof:lastmodified":1601068497,
+    "wof:name":"Dal\u2019zavodskoye",
     "wof:parent_id":1108734387,
     "wof:placetype":"locality",
     "wof:population":332,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.